### PR TITLE
fix: update JDT LS download URL to v1.57.0

### DIFF
--- a/src/android_source_explorer/lsp/lsp_installer.py
+++ b/src/android_source_explorer/lsp/lsp_installer.py
@@ -10,7 +10,7 @@ from rich.console import Console
 console = Console()
 
 KOTLIN_LS_URL = "https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip"
-JDT_LS_URL = "https://download.eclipse.org/jdtls/milestones/1.40.0/jdt-language-server-1.40.0-202410241517.tar.gz"
+JDT_LS_URL = "https://download.eclipse.org/jdtls/milestones/1.57.0/jdt-language-server-1.57.0-202602261110.tar.gz"
 
 def install_lsp_servers(lsp_dir: Path):
     """Download and extract Kotlin and Java LSP servers."""


### PR DESCRIPTION
## Summary
- The JDT LS v1.40.0 download URL returns 404 as it was removed from Eclipse's mirror
- Updated to the latest available version (v1.57.0)

## Test plan
- [ ] Run `uv run android-source-explorer sync --lsp` and verify JDT LS downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)